### PR TITLE
add source subscribe closure

### DIFF
--- a/src/schedule-retry.ts
+++ b/src/schedule-retry.ts
@@ -1,35 +1,30 @@
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
-export function scheduleRetry(...timeouts: number[]) {
+export function scheduleRetry(timeouts: number[]) {
 
   return function (source: Observable<any>) {
     let tryNumber = 0;
-    return new Observable((observer) => {
+    return new Observable((observer) => sourceSubscribe(observer));
+    
+    function sourceSubscribe(observer: Observer<any>) {
       source.subscribe(
         (val) => observer.next(val),
         (err) => doSubscribe(observer),
         () => observer.complete()
-      )
-    });
+      );
+    }
 
     function doSubscribe(observer: Observer<any>) {
       const timeoutTime = timeouts[tryNumber];
       if (typeof timeoutTime === 'undefined') {
         observer.complete();
       } else {
-
         tryNumber++;
         setTimeout(() => {
-          source.subscribe(
-            (val) => observer.next(val),
-            (err) => doSubscribe(observer),
-            () => observer.complete()
-          )
+          sourceSubscribe(observer);
         }, timeoutTime);
       }
     }
-
-
   };
 }

--- a/src/schedule-retry.ts
+++ b/src/schedule-retry.ts
@@ -1,8 +1,13 @@
 import { Observable } from 'rxjs/Observable';
 import { Observer } from 'rxjs/Observer';
 
-export function scheduleRetry(timeouts: number[]) {
+interface ScheduleRetryFunc {
+    (...timeouts: number[]): Function;
+    (timeouts: number[]): Function;
+}
 
+export const scheduleRetry : ScheduleRetryFunc = function (...timeouts : any[]): Function {
+  timeouts = Array.isArray(timeouts[0]) ? timeouts[0] : timeouts;
   return function (source: Observable<any>) {
     let tryNumber = 0;
     return new Observable((observer) => sourceSubscribe(observer));

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -20,11 +20,11 @@ describe('something', () => {
   });
 
   it ('should return a function', () => {
-    expect(scheduleRetry(0, 200, 500)).to.be.a('function');
+    expect(scheduleRetry([0, 200, 500])).to.be.a('function');
   });
 
   it ('should return a function that returns and instance of an Observable', () => {
-    expect(scheduleRetry(0, 200, 500)(new Observable())).to.be.instanceof(Observable);
+    expect(scheduleRetry([0, 200, 500])(new Observable())).to.be.instanceof(Observable);
   });
 
   it ('should retry an observable as many times as there are args', () => {
@@ -32,7 +32,7 @@ describe('something', () => {
     const mock$ = mockSubject.asObservable();
     const subscribeSpy = spy(mock$, 'subscribe');
 
-    scheduleRetry(0, 500)(mock$).subscribe();
+    scheduleRetry([0, 500])(mock$).subscribe();
     mockSubject.error({});
     clock.tick(501);
     expect(subscribeSpy).to.have.been.calledThrice;

--- a/src/test.spec.ts
+++ b/src/test.spec.ts
@@ -20,11 +20,15 @@ describe('something', () => {
   });
 
   it ('should return a function', () => {
-    expect(scheduleRetry([0, 200, 500])).to.be.a('function');
+    expect(scheduleRetry(0, 200, 500)).to.be.a('function');
+  });
+  
+  it ('should accept an array of numbers', () => {
+    expect(scheduleRetry([0, 200, 500])).to.not.throw;
   });
 
   it ('should return a function that returns and instance of an Observable', () => {
-    expect(scheduleRetry([0, 200, 500])(new Observable())).to.be.instanceof(Observable);
+    expect(scheduleRetry(0, 200, 500)(new Observable())).to.be.instanceof(Observable);
   });
 
   it ('should retry an observable as many times as there are args', () => {
@@ -32,7 +36,7 @@ describe('something', () => {
     const mock$ = mockSubject.asObservable();
     const subscribeSpy = spy(mock$, 'subscribe');
 
-    scheduleRetry([0, 500])(mock$).subscribe();
+    scheduleRetry(0, 500)(mock$).subscribe();
     mockSubject.error({});
     clock.tick(501);
     expect(subscribeSpy).to.have.been.calledThrice;


### PR DESCRIPTION
For retry counts that exceed 4 times I thought it might make sense to support an array data type as the first param. We could also expose convenience methods for generating this param e.g.
```
// returns [0, 100, 100, 100, 100, 100, 200, 300, 500, 700, 1000]
export function easeOff(max = 1){
  const ms = [];
  for ( i = 0; i <= max; i += 0.1 ) {
    ms.push(Math.ceil(Math.pow( i, 4 ) * 10) * 100);
  }
  return ms;
}

scheduleRetry(easeOff())(observable).subscribe();
```
![powerto](https://user-images.githubusercontent.com/104585/33669546-ce19cee2-da70-11e7-9ea2-7861ee1bec6a.png)

